### PR TITLE
changed distutils to setuptools to allow use of develop as an option to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='RITSAR',
       version='1.0',


### PR DESCRIPTION
This is a simple change that I made so that the "develop" option would be available to setup.py in addition to "build" and "install". This makes it easier to play around with the code without actually installing it.