### PR TITLE
RITSAR has exceptions when used with Anaconda 25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.egg-info/
+build/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@ Synthetic Aperture Radar (SAR) Image Processing Toolbox for Python
 
 Before installation, please make sure you have the following:
 - SciPy. Comes with many Python distributions such as Enthought Canopy, Python(x,y), and Anaconda.  Development was done using the Anaconda distribution which can be downloaded for free from https://store.continuum.io/cshop/anaconda/. 
-- OpenCV (optional). If using the omega-k algorithm, OpenCV is required. Instructions for installing OpenCV for Python can be found at  https://opencv-python-tutroals.readthedocs.org/en/latest/py_tutorials/py_setup/py_table_of_contents_setup/py_table_of_contents_setup.html#py-table-of-content-setup.
+- OpenCV (optional). If using the omega-k algorithm, OpenCV is required. Can be installed from the command line using
+
+  $ pip install opencv-python
+
+alternatively, instructions for installing OpenCV for Python can be found at  https://opencv-python-tutroals.readthedocs.org/en/latest/py_tutorials/py_setup/py_table_of_contents_setup/py_table_of_contents_setup.html#py-table-of-content-setup.
 - Spectral (optional).  Needed to interface with .envi files.  Can be installed from the command line using
 
   $ pip install spectral
@@ -20,7 +24,7 @@ Once you've ensured the required libraries are up-to-date, download the zip file
 
 $ cd \<ritsar_dir\>
 
-$ python setup.py install
+$ python -m pip install .
 
 then...
 

--- a/examples/DSBP_demo.py
+++ b/examples/DSBP_demo.py
@@ -96,7 +96,7 @@ extent = [u.min(), u.max(), v.min(), v.max()]
 
 plt.subplot(1,2,1)
 plt.title('Full Backprojection')
-imgTools.imshow(img_bp[177-N/2:177+N/2,202-N/2:202+N/2], dB_scale = [-25,0], extent = extent)
+imgTools.imshow(img_bp[177-N//2:177+N//2,202-N//2:202+N//2], dB_scale = [-25,0], extent = extent)
 plt.xlabel('meters'); plt.ylabel('meters')
 
 plt.subplot(1,2,2)

--- a/examples/dictionaries/SARplatform.py
+++ b/examples/dictionaries/SARplatform.py
@@ -59,10 +59,10 @@ def plat_dict(aux = []):
     
     #Vector to scene center at synthetic aperture center
     if np.mod(npulses,2)>0:
-        R_c = pos[npulses/2]
+        R_c = pos[npulses//2]
     else:
         R_c = np.mean(
-                pos[npulses/2-1:npulses/2+1],
+                pos[npulses//2-1:npulses//2+1],
                 axis = 0)
                     
     #Coherent integration angle

--- a/examples/dictionaries/SARplatformUHF.py
+++ b/examples/dictionaries/SARplatformUHF.py
@@ -55,10 +55,10 @@ def plat_dict(aux = []):
     
     #Vector to scene center at synthetic aperture center
     if np.mod(npulses,2)>0:
-        R_c = pos[npulses/2]
+        R_c = pos[npulses//2]
     else:
         R_c = np.mean(
-                pos[npulses/2-1:npulses/2+1],
+                pos[npulses//2-1:npulses//2+1],
                 axis = 0)
                     
     #Coherent integration angle

--- a/ritsar/imgTools.py
+++ b/ritsar/imgTools.py
@@ -161,7 +161,7 @@ def polar_format(phs, platform, img_plane, taylor = 20):
     #Interpolate in along track direction to obtain polar formatted data
     real_polar = np.zeros([nv,nu])
     imag_polar = np.zeros([nv,nu])
-    isSort = (ky_new[npulses/2, nu/2] < ky_new[npulses/2+1, nu/2])
+    isSort = (ky_new[npulses//2, nu//2] < ky_new[npulses//2+1, nu//2])
     if isSort:
         for i in range(nu):
             print('cross-range interpolating for sample %i'%(i+1))
@@ -291,7 +291,7 @@ def backprojection(phs, platform, img_plane, taylor = 20, upsample = 6, prnt = T
     #Derive parameters
     nu = u.size
     nv = v.size
-    k_c = k_r[nsamples/2]
+    k_c = k_r[nsamples//2]
     
     #Create window
     win_x = sig.taylor(nsamples,taylor)
@@ -329,7 +329,7 @@ def backprojection(phs, platform, img_plane, taylor = 20, upsample = 6, prnt = T
         Q_hat = Q_real+1j*Q_imag        
         img += Q_hat*np.exp(-1j*k_c*dr_i)
     
-    r0 = np.array([pos[npulses/2]]).T
+    r0 = np.array([pos[npulses//2]]).T
     dr_i = norm(r0)-norm(r-r0, axis = 0)
     img = img*np.exp(1j*k_c*dr_i)   
     img = np.reshape(img, [nv, nu])[::-1,:]
@@ -521,8 +521,8 @@ def DS(phs, platform, img_plane, center=None, size=None, derate = 1.05, taylor =
     #update platform
     platformDS['nsamples'] = freq.size
     platformDS['freq']     = freq
-    deltaF = freq[freq.size/2]-freq[freq.size/2-1] #Assume sample spacing can be determined by difference between last two values (first two are distorted by decimation filter)
-    freq   = freq[freq.size/2]+np.arange(-freq.size/2,freq.size/2)*deltaF
+    deltaF = freq[freq.size//2]-freq[freq.size//2-1] #Assume sample spacing can be determined by difference between last two values (first two are distorted by decimation filter)
+    freq   = freq[freq.size//2]+np.arange(-freq.size/2,freq.size/2)*deltaF
     platformDS['k_r'] = 4*pi*freq/c
 
     #interpolate phs and pos using uniform azimuth spacing
@@ -638,7 +638,7 @@ def FFBP(phs, platform, img_plane, N=3, derate = 1.05, taylor = 20, n = 32, beta
         
             #Derive parameters
             img_plane_sub = dict(img_planeDS)
-            full_size = np.array([v.size, u.size], dtype = np.int)
+            full_size = np.array([v.size, u.size], dtype = np.int64)
             sub_size = np.array(full_size/2, dtype = int)
             img_FFBP = np.zeros(full_size)
         
@@ -696,7 +696,7 @@ def FFBP(phs, platform, img_plane, N=3, derate = 1.05, taylor = 20, n = 32, beta
     n_img = image_number-1
     
     #Derive parameters
-    full_size = np.array([v.size, u.size], dtype = np.int)
+    full_size = np.array([v.size, u.size], dtype = np.int64)
     sub_size = np.array(full_size/(2**N), dtype = int)
     img_FFBP = np.zeros(full_size)
     
@@ -755,7 +755,7 @@ def FFBPmp(phs, platform, img_plane, N=3, derate = 1.05, taylor = 20, n = 32, be
     
     #Derive parameters
     img_plane_sub = dict(img_plane)
-    full_size = np.array([v.size, u.size], dtype = np.int)
+    full_size = np.array([v.size, u.size], dtype = np.int64)
     sub_size = np.array(full_size/2, dtype = int)
     img_FFBP = np.zeros(full_size)
     
@@ -816,7 +816,7 @@ def FFBPmp(phs, platform, img_plane, N=3, derate = 1.05, taylor = 20, n = 32, be
     output = [p.get() for p in results]
     
     #Derive parameters
-    full_size = np.array([v.size, u.size], dtype = np.int)
+    full_size = np.array([v.size, u.size], dtype = np.int64)
     sub_size = np.array(full_size/2, dtype = int)
     img_FFBP = np.zeros(full_size)
     

--- a/ritsar/imgTools.py
+++ b/ritsar/imgTools.py
@@ -394,8 +394,8 @@ def DSBP(phs, platform, img_plane, center=None, size=None, derate = 1.05, taylor
     #update platform
     platformDS['nsamples'] = freq.size
     platformDS['freq']     = freq
-    deltaF = freq[freq.size/2]-freq[freq.size/2-1] #Assume sample spacing can be determined by difference between last two values (first two are distorted by decimation filter)
-    freq   = freq[freq.size/2]+np.arange(-freq.size/2,freq.size/2)*deltaF
+    deltaF = freq[freq.size//2]-freq[freq.size//2-1] #Assume sample spacing can be determined by difference between last two values (first two are distorted by decimation filter)
+    freq   = freq[freq.size//2]+np.arange(-freq.size/2,freq.size/2)*deltaF
     platformDS['k_r'] = 4*pi*freq/c
 
     #interpolate phs and pos using uniform azimuth spacing
@@ -449,8 +449,8 @@ def DSBP(phs, platform, img_plane, center=None, size=None, derate = 1.05, taylor
         img_planeDS['v']    = np.arange(-size[0]/2,size[0]/2)*dv
 		
         #get pixel locs for sub_image
-        u_index = np.arange(center_index[1]-size[1]/2,center_index[1]+size[1]/2)
-        v_index = np.arange(center_index[0]-size[0]/2,center_index[0]+size[0]/2)
+        u_index = np.arange(center_index[1]-size[1]//2,center_index[1]+size[1]//2)
+        v_index = np.arange(center_index[0]-size[0]//2,center_index[0]+size[0]//2)
         uu,vv = np.meshgrid(u_index,v_index)
         locs_index = np.ravel_multi_index((vv.flatten(),uu.flatten()),(v.size,u.size))
         img_planeDS['pixel_locs']     = img_plane['pixel_locs'][:,locs_index]-np.array([center]).T
@@ -1080,11 +1080,11 @@ def autoFocus2(img, win = 'auto', win_params = [100,0.5]):
             #For all other iterations, use twice the 30 dB threshold
             else:
                 width = np.sum(s>-30)
-            window = np.arange(npulses/2-width/2,npulses/2+width/2)
+            window = np.arange(npulses/2-width/2,npulses/2+width/2,dtype=int)
         else:
             #Compute window width using win_params if win not set to 'auto'    
             width = int(win_params[0]*win_params[1]**iii)
-            window = np.arange(npulses/2-width/2,npulses/2+width/2)
+            window = np.arange(npulses/2-width/2,npulses/2+width/2,dtype=int)
             if width<5:
                 break
         

--- a/ritsar/phsRead.py
+++ b/ritsar/phsRead.py
@@ -73,10 +73,10 @@ def AFRL(directory, pol, start_az, n_az=3):
                     
         #Vector to scene center at synthetic aperture center
         if np.mod(npulses,2)>0:
-            R_c = pos[npulses/2]
+            R_c = pos[npulses//2]
         else:
             R_c = np.mean(
-                    pos[npulses/2-1:npulses/2+1],
+                    pos[npulses//2-1:npulses//2+1],
                     axis = 0)
         
         #Save values to dictionary for export
@@ -105,10 +105,10 @@ def AFRL(directory, pol, start_az, n_az=3):
         pos = np.vstack((pos, platform[i]['pos']))
                        
     if np.mod(npulses,2)>0:
-        R_c = pos[npulses/2]
+        R_c = pos[npulses//2]
     else:
         R_c = np.mean(
-                pos[npulses/2-1:npulses/2+1],
+                pos[npulses//2-1:npulses//2+1],
                 axis = 0)
                        
     #Replace Dictionary values

--- a/ritsar/phsRead.py
+++ b/ritsar/phsRead.py
@@ -255,10 +255,10 @@ def Sandia(directory):
     k_r = 2*omega/c
     
     if np.mod(npulses,2)>0:
-        R_c = pos[npulses/2]
+        R_c = pos[npulses//2]
     else:
         R_c = np.mean(
-                pos[npulses/2-1:npulses/2+1],
+                pos[npulses//2-1:npulses//2+1],
                 axis = 0)
     
     platform = \
@@ -317,7 +317,7 @@ def DIRSIG(directory):
         pos_dirs.append(float(children[0].text))
         pos_dirs.append(float(children[1].text))
         pos_dirs.append(float(children[2].text))
-    pos_dirs = np.asarray(pos_dirs).reshape([len(pos_dirs)/3,3])
+    pos_dirs = np.asarray(pos_dirs).reshape([len(pos_dirs)//3,3])
     
     t_dirs=[]
     for children in root.iter('datetime'):
@@ -368,10 +368,10 @@ def DIRSIG(directory):
     
     #Vector to scene center at synthetic aperture center
     if np.mod(npulses,2)>0:
-        R_c = pos[npulses/2]
+        R_c = pos[npulses//2]
     else:
         R_c = np.mean(
-                pos[npulses/2-1:npulses/2+1],
+                pos[npulses//2-1:npulses//2+1],
                 axis = 0)
                 
     #Derived Parameters

--- a/ritsar/signal.py
+++ b/ritsar/signal.py
@@ -170,10 +170,10 @@ def decimate(x, q, n=None, axis=-1, beta = None, cutoff = 'nyq'):
     if beta == None:
         beta = 1.*n/8
     
-    padlen = n/2
+    padlen = n//2
     
     if cutoff == 'nyq':
-        eps = np.finfo(np.float).eps
+        eps = np.finfo(np.float64).eps
         cutoff = 1.-eps
     
     window = ('kaiser', beta)
@@ -182,6 +182,7 @@ def decimate(x, q, n=None, axis=-1, beta = None, cutoff = 'nyq'):
     b = firwin(n,  cutoff/ q, window=window)
     y = filtfilt(b, [a], x, axis=axis, padlen = padlen)
     
-    sl = [slice(None)] * y.ndim
-    sl[axis] = slice(None, None, q)
+    sl = [np.s_[::]] * y.ndim
+    sl[axis] = np.s_[::q]
+    sl = tuple(sl)
     return y[sl]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name='RITSAR',
-      version='1.0',
+      version='1.0.1',
       description='Synthetic Aperture Radar (SAR) Image Processing Toolbox for Python',
       author='Douglas Macdonald',
       author_email='dm6718@g.rit.edu',


### PR DESCRIPTION
Fixed numerous index calculations that didn't use integer division.
    
Changed np.int to np.int64 and np.float to np.float64 as needed.
    
Changed signal.decimate to use a tuple of slices to index the return array (also used np.s_
rather than slice objects for readability).
    
Rolled the version to 1.0.1
    
Updated the README due to setuptools deprecations in setup.py and modified the opencv installation instructions.
    
Added a .gitignore file